### PR TITLE
Bump ffmpeg-for-homebridge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -431,9 +431,9 @@
       "integrity": "sha512-5rQdinSsycpzvAoHga2EDn+LRX1d5xLFsuNG0Kg61JrAT/tASXcLL0nf/33v+sAxlQcfYmWbTURa1mmAf55jGw=="
     },
     "ffmpeg-for-homebridge": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ffmpeg-for-homebridge/-/ffmpeg-for-homebridge-0.0.4.tgz",
-      "integrity": "sha512-3Lpw7SgL9M0fF4gft7XLBUKeUWe+yGPEXpQymn2Tzr2uNBv1bGh6UzUBSf2qYXMdJaEhQhO4Ouq5REUE9wuL9Q==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ffmpeg-for-homebridge/-/ffmpeg-for-homebridge-0.0.5.tgz",
+      "integrity": "sha512-MEZIxcwzueSu6XCGcmJljMDvT+Y0bRz3VupMZXEnFszzwyk7PvRPKp/inKcKMksMKcSj8WQ2FwGNBoBHnZLqig==",
       "requires": {
         "detect-libc": "^1.0.3",
         "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "nodemon": ">=2.0.2"
   },
   "dependencies": {
+    "debug": "^4.1.1",
+    "ffmpeg-for-homebridge": "0.0.5",
     "googleapis": ">=50.0.0",
-    "ffmpeg-for-homebridge": "0.0.4",
-    "ip": "^1.1.5",
-    "debug": "^4.1.1"
+    "ip": "^1.1.5"
   }
 }


### PR DESCRIPTION
This update adds support for the [`speex`](https://www.speex.org/) codec and support for using [`alsa`](https://www.alsa-project.org/wiki/Main_Page) drivers for audio input.