### PR TITLE
Add MQTT to motion Detect 

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -13,6 +13,18 @@
       "title": "Video Processor",
       "type": "string"
     },
+      "mqtt": {
+      "title": "Server MQTT",
+      "type": "string"
+    },
+    "portmqtt": {
+      "title": "Port MQTT",
+      "type": "integer"
+    },
+    "topic": {
+      "title": "Topic MQTT",
+      "type": "string"
+    },
     "cameras": {
       "type": "array",
       "items": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "ts-jest": "^25.5.1",
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "mqtt": "^2.18.2"
   },
   "dependencies": {
     "ffmpeg-for-homebridge": "0.0.6",


### PR DESCRIPTION
Just publish to topic, no message, homebridge/motion/Camera_name.
You must add _ to your camera if you have space in the name.

```
{
  "platform": "Camera-ffmpeg",
  "mqtt": "127.0.0.1",
  "topics": "homebridge/motion/#",
  "portmqtt": 1883,
  "cameras": [
    {
      "name": "Camera name",
      "motion": true,
      "videoConfig": {
        "source": "-re -i http://10.0.0.1",
        "stillImageSource": "-i http://10.0.0.1",
        "maxStreams": 5,
        "maxWidth": 1280,
        "maxHeight": 720,
        "maxFPS": 15,
        "maxBitrate": 1000
      }
    }
  ]
}
```