### PR TITLE
Fix packetsize config and various refactoring

### DIFF
--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -55,8 +55,8 @@ export class StreamingDelegate implements CameraStreamingDelegate {
   private videoProcessor = '';
   private audio = '';
   private acodec = '';
-  private packetSize = '';
   private fps = '';
+  private packetSize: number;
   private maxBitrate = '';
   private minBitrate = '';
   private vflip = '';
@@ -80,7 +80,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
     this.videoProcessor = videoProcessor || pathToFfmpeg || 'ffmpeg';
     this.audio = this.ffmpegOpt.audio;
     this.acodec = this.ffmpegOpt.acodec;
-    this.packetSize = this.ffmpegOpt.packetSize;
+    this.packetSize = this.ffmpegOpt.packetSize || 1316;
     this.fps = this.ffmpegOpt.maxFPS || 10;
     this.maxBitrate = this.ffmpegOpt.maxBitrate || 300;
     this.minBitrate = this.ffmpegOpt.minBitrate || 0;
@@ -277,7 +277,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
         }
         // const rtcpInterval = video.rtcp_interval; // usually 0.5
         const sampleRate = audio.sample_rate;
-        const mtu = video.mtu; // maximum transmission unit
+        const mtu = this.packetSize || video.mtu; // maximum transmission unit
 
         const address = sessionInfo.address;
         const videoPort = sessionInfo.videoPort;

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -305,7 +305,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
 
         let fcmd = this.ffmpegOpt.source;
 
-        this.log(`Starting video stream (${width}x${height}, ${fps} fps, ${videoMaxBitrate} kbps, ${mtu} mtu)...`);
+        this.log(`Starting ${this.name} video stream (${width}x${height}, ${fps} fps, ${videoMaxBitrate} kbps, ${mtu} mtu)...`);
 
         const ffmpegVideoArgs =
           ' -map ' +
@@ -436,7 +436,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
         }
       }
       delete this.ongoingSessions[sessionId];
-      this.log('Stopped streaming session!');
+      this.log(`Stopped ${this.name} video stream!`);
     } catch (e) {
       this.log.error('Error occurred terminating the video process!');
       this.log.error(e);

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -436,7 +436,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
         }
       }
       delete this.ongoingSessions[sessionId];
-      this.log.debug('Stopped streaming session!');
+      this.log('Stopped streaming session!');
     } catch (e) {
       this.log.error('Error occurred terminating the video process!');
       this.log.error(e);

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -87,7 +87,6 @@ export class StreamingDelegate implements CameraStreamingDelegate {
     if (this.minBitrate > this.maxBitrate) {
       this.minBitrate = this.maxBitrate;
     }
-    this.debug = this.ffmpegOpt.debug;
     this.additionalCommandline = this.ffmpegOpt.additionalCommandline || '-tune zerolatency';
     this.vflip = this.ffmpegOpt.vflip || false;
     this.hflip = this.ffmpegOpt.hflip || false;

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -305,9 +305,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
 
         let fcmd = this.ffmpegOpt.source;
 
-        this.log.debug(
-          `Starting video stream (${width}x${height}, ${fps} fps, ${videoMaxBitrate} kbps, ${mtu} mtu)...`,
-        );
+        this.log(`Starting video stream (${width}x${height}, ${fps} fps, ${videoMaxBitrate} kbps, ${mtu} mtu)...`);
 
         const ffmpegVideoArgs =
           ' -map ' +


### PR DESCRIPTION
- Fix using the config `packetSize` when configuring ffmpeg `pkt_size`, if not set, fallback to `video.mtu` (fixes #564)
- Fixed declaring `this.debug` twice
- Refactor most ffmpeg code to always use class properties rather than `ffmpegOpt` directly (makes defaults more consistent and less duplicated)
- Fix "Starting video stream" to log without debug mode enabled (like it did in v1.3.0)