### PR TITLE
Tweak image snapshot to use -frames:v instead of -t

### DIFF
--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -55,8 +55,8 @@ export class StreamingDelegate implements CameraStreamingDelegate {
   private videoProcessor = '';
   private audio = '';
   private acodec = '';
-  private packetSize = '';
   private fps = '';
+  private packetSize: number;
   private maxBitrate = '';
   private minBitrate = '';
   private vflip = '';
@@ -80,7 +80,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
     this.videoProcessor = videoProcessor || pathToFfmpeg || 'ffmpeg';
     this.audio = this.ffmpegOpt.audio;
     this.acodec = this.ffmpegOpt.acodec;
-    this.packetSize = this.ffmpegOpt.packetSize;
+    this.packetSize = this.ffmpegOpt.packetSize || 1316;
     this.fps = this.ffmpegOpt.maxFPS || 10;
     this.maxBitrate = this.ffmpegOpt.maxBitrate || 300;
     this.minBitrate = this.ffmpegOpt.minBitrate || 0;
@@ -277,7 +277,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
         }
         // const rtcpInterval = video.rtcp_interval; // usually 0.5
         const sampleRate = audio.sample_rate;
-        const mtu = video.mtu; // maximum transmission unit
+        const mtu = this.packetSize || video.mtu; // maximum transmission unit
 
         const address = sessionInfo.address;
         const videoPort = sessionInfo.videoPort;

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -305,7 +305,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
 
         let fcmd = this.ffmpegOpt.source;
 
-        this.log(`Starting video stream (${width}x${height}, ${fps} fps, ${videoMaxBitrate} kbps, ${mtu} mtu)...`);
+        this.log(`Starting ${this.name} video stream (${width}x${height}, ${fps} fps, ${videoMaxBitrate} kbps, ${mtu} mtu)...`);
 
         const ffmpegVideoArgs =
           ' -map ' +
@@ -436,7 +436,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
         }
       }
       delete this.ongoingSessions[sessionId];
-      this.log('Stopped streaming session!');
+      this.log(`Stopped ${this.name} video stream!`);
     } catch (e) {
       this.log.error('Error occurred terminating the video process!');
       this.log.error(e);

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -141,13 +141,13 @@ export class StreamingDelegate implements CameraStreamingDelegate {
     try {
       const ffmpeg = spawn(
         this.videoProcessor,
-        (imageSource + ' -t 1' + (vf.length > 0 ? ' -vf ' + vf.join(',') : '') + ' -f image2 -').split(' '),
+        (imageSource + ' -frames:v 1' + (vf.length > 0 ? ' -vf ' + vf.join(',') : '') + ' -f image2 -').split(' '),
         { env: process.env },
       );
       let imageBuffer = Buffer.alloc(0);
       this.log(`Snapshot from ${this.name} at ${resolution}`);
       if (this.debug) {
-        this.log(`ffmpeg ${imageSource} -t 1${vf.length > 0 ? ' -vf ' + vf.join(',') : ''} -f image2 -`);
+        this.log(`ffmpeg ${imageSource} -frames:v 1${vf.length > 0 ? ' -vf ' + vf.join(',') : ''} -f image2 -`);
       }
       ffmpeg.stdout.on('data', function (data: any) {
         imageBuffer = Buffer.concat([imageBuffer, data]);

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -436,7 +436,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
         }
       }
       delete this.ongoingSessions[sessionId];
-      this.log.debug('Stopped streaming session!');
+      this.log('Stopped streaming session!');
     } catch (e) {
       this.log.error('Error occurred terminating the video process!');
       this.log.error(e);

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -87,7 +87,6 @@ export class StreamingDelegate implements CameraStreamingDelegate {
     if (this.minBitrate > this.maxBitrate) {
       this.minBitrate = this.maxBitrate;
     }
-    this.debug = this.ffmpegOpt.debug;
     this.additionalCommandline = this.ffmpegOpt.additionalCommandline || '-tune zerolatency';
     this.vflip = this.ffmpegOpt.vflip || false;
     this.hflip = this.ffmpegOpt.hflip || false;

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -305,9 +305,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
 
         let fcmd = this.ffmpegOpt.source;
 
-        this.log.debug(
-          `Starting video stream (${width}x${height}, ${fps} fps, ${videoMaxBitrate} kbps, ${mtu} mtu)...`,
-        );
+        this.log(`Starting video stream (${width}x${height}, ${fps} fps, ${videoMaxBitrate} kbps, ${mtu} mtu)...`);
 
         const ffmpegVideoArgs =
           ' -map ' +


### PR DESCRIPTION
The HAP-NodeJS camera example uses `-vframes 1` to capture just one frame https://github.com/homebridge/HAP-NodeJS/blob/master/src/accessories/Camera_accessory.ts#L71

`-frames:v` is the newer version of `-vframes` which is deprecated https://ffmpeg.org/ffmpeg.html#Video-Options