### PR TITLE
Support for MQTT Resetting of Motion Sensor

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -22,7 +22,7 @@
     "portmqtt": {
       "title": "Port MQTT",
       "type": "integer",
-      "placeholder": "1234"
+      "placeholder": "1883"
     },
     "topic": {
       "title": "Topic MQTT",

--- a/config.schema.json
+++ b/config.schema.json
@@ -76,6 +76,13 @@
             "title": "Enable Manual Automation Motion and/or Doorbell Switch",
             "type": "boolean"
           },
+          "motionTimeout": {
+            "title": "Number of Seconds for Automatic Motion Reset",
+            "type": "integer",
+            "placeholder": 1,
+            "minimum": -1,
+            "description": "Set to -1 to disable."
+          },
           "videoConfig": {
             "title": "Video Configuration",
             "type": "object",
@@ -230,7 +237,8 @@
                 "cameras[].motion",
                 "cameras[].doorbell",
                 "cameras[].doorbellSwitch",
-                "cameras[].switches"
+                "cameras[].switches",
+                "cameras[].motionTimeout"
               ]
             },
             {

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,37 +206,31 @@ class FfmpegPlatform implements DynamicPlatformPlugin {
     this.accessories.push(cameraAccessory);
   }
 
-  mqttHandler(name:string): void  {
-
+  mqttHandler(name:string): void {
     this.accessories.forEach((accessory: PlatformAccessory) => {
-        if (
-          accessory.displayName == name
-          )
-         {
+        if (accessory.displayName == name) {
           this.log("Switch Motion Detect On :", accessory.displayName);
-          const motionSenSor = accessory.getService(hap.Service.MotionSensor);
-          const doorbellSenSor = accessory.getService(hap.Service.Doorbell);
-          if (motionSenSor){
-            motionSenSor.setCharacteristic(hap.Characteristic.MotionDetected, 1);
+          const motionSensor = accessory.getService(hap.Service.MotionSensor);
+          const doorbellSensor = accessory.getService(hap.Service.Doorbell);
+          if (motionSensor) {
+            motionSensor.setCharacteristic(hap.Characteristic.MotionDetected, 1);
             setTimeout(function () {
-                  motionSenSor.setCharacteristic(
-                hap.Characteristic.MotionDetected,0);
+                  motionSensor.setCharacteristic(hap.Characteristic.MotionDetected, 0);
                 }, 1000);
           }
-          if (doorbellSenSor) {
-            doorbellSenSor.updateCharacteristic(
-            hap.Characteristic.ProgrammableSwitchEvent,
-            hap.Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS,
-            );
-            }
+          if (doorbellSensor) {
+            doorbellSensor.updateCharacteristic(
+              hap.Characteristic.ProgrammableSwitchEvent,
+              hap.Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
+          }
         }
-      })
+      });
    }
 
   didFinishLaunching(): void {
     if (this.config.mqtt) {
       this.log('Setting up mqtt connection...');
-      const servermqtt = this.config.mqtt;
+      const servermqtt = this.config.mqtt || '127.0.0.1';
       const port = this.config.portmqtt || '1883';
       const topics = this.config.topics || 'homebridge/motion';
       const client = mqtt.connect('mqtt://' + servermqtt + ':' + port);


### PR DESCRIPTION
As discussed in #575 this adds support for resetting the motion sensor via MQTT.

To reset the sensor, publish a message with the camera name to `topic`/reset . So the default would be 'homebridge/motion/reset'.

If you're using MQTT to reset the sensor, you probably don't want the timeout firing to automatically reset the sensor, so I added a configuration option for the number of seconds for the timeout to fire. It defaults to 1, like the previous code worked. However, if you set it to -1, that timeout will be disabled, so the sensor will stay active until the reset MQTT message is received.