### PR TITLE
Fix bug with doorbell switch

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -135,13 +135,10 @@
               "preserveRatio": {
                 "title": "Preserve Ratio",
                 "type": "string",
-                "description": "Can be set to either 'W' or 'H' with respective obvious meanings.",
-                "typeahead": {
-                  "source": [
-                    "W",
-                    "H"
-                  ]
-                }
+                "oneOf": [
+                  { "title": "Width", "enum": ["W"] },
+                  { "title": "Height", "enum": ["H"] }
+                ]
               },
               "vcodec": {
                 "title": "Video Codec",

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,12 +138,13 @@ class FfmpegPlatform implements DynamicPlatformPlugin {
       }
 
       if (cameraConfig.doorbellSwitch) {
-        cameraAccessory
-          .addService(hap.Service.StatelessProgrammableSwitch, 'DoorbellSwitch')
+        const doorbellSwitchService = new hap.Service.StatelessProgrammableSwitch(`${cameraConfig.name} Doorbell Switch`, 'DoorbellSwitch');
+        doorbellSwitchService
           .getCharacteristic(hap.Characteristic.ProgrammableSwitchEvent)
           .setProps({
             maxValue: hap.Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS,
           });
+        cameraAccessory.addService(doorbellSwitchService);
       }
     }
     if (cameraConfig.motion) {


### PR DESCRIPTION
This should resolve the bug identified in #621 , if the doorbellSwitch config option is set, the plugin will fail after the first time you restart Homebridge.